### PR TITLE
DEV-578 websockets

### DIFF
--- a/src/main/java/com/cylentsystems/dropwizard/sisu/SisuApplication.java
+++ b/src/main/java/com/cylentsystems/dropwizard/sisu/SisuApplication.java
@@ -71,6 +71,10 @@ public abstract class SisuApplication<T extends Configuration> extends Applicati
 
   protected void customize(T configuration, Environment environment) {}
 
+    protected Injector getInjector() {
+        return this.injector;
+    }
+
 
     private void runWithInjector(T configuration, Environment environment, Injector injector)
       throws Exception {

--- a/src/main/java/com/cylentsystems/dropwizard/sisu/Websocket.java
+++ b/src/main/java/com/cylentsystems/dropwizard/sisu/Websocket.java
@@ -1,5 +1,8 @@
 package com.cylentsystems.dropwizard.sisu;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * *****************************************************************************
  * Copyright (c) 2014
@@ -8,5 +11,6 @@ package com.cylentsystems.dropwizard.sisu;
  * Cylent Systems - initial API and implementation
  * *****************************************************************************
  */
+@Retention(RetentionPolicy.RUNTIME)
 public @interface Websocket {
 }


### PR DESCRIPTION
Changes needed to integrate atmosphere into dropwizard.

The Websocket annotation had the wrong retention policy.

Needed to add an accessor for the guice injector. The atmosphere object factory needs access to this to properly instantiate/inject websocket resources
